### PR TITLE
Fix the mod author gradle property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,6 +41,6 @@ mod_version=2.2.0
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html
 mod_group_id=com.leclowndu93150.corpsecurioscompat
 # The authors of the mod. This is a simple text string that is used for display purposes in the mod list.
-mod_authors=YourNameHere, OtherNameHere
+mod_authors=Leclowndu93150
 # The description of the mod. This is a simple multiline text string that is used for display purposes in the mod list.
 mod_description=Adds compatibility between Corpse and Curios


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9224740b-aa87-4473-92f5-90fb0a1d315a)
The `mod_authors` property tell the TOML info. You still had it on the default "your name here", so this PR fixes it